### PR TITLE
MC-1087 PHP reserves all function names starting with __ as magical

### DIFF
--- a/source/paysafe.php
+++ b/source/paysafe.php
@@ -31,7 +31,7 @@ if (!function_exists('curl_version')) {
     throw new Exception('CURL is required for the Paysafe SDK.');
 }
 
-function __PaysafeAutoloader($className)
+function paysafeAutoloader($className)
 {
     $classPath = str_replace("\\", DIRECTORY_SEPARATOR, $className);
     if (($classFile = realpath(__DIR__ . DIRECTORY_SEPARATOR . $classPath . '.php'))) {
@@ -39,4 +39,4 @@ function __PaysafeAutoloader($className)
     }
 }
 
-spl_autoload_register('__PaysafeAutoloader');
+spl_autoload_register('paysafeAutoloader');


### PR DESCRIPTION
PHP reserves all function names starting with __ as magical. It is recommended that you do not use function names with __ in PHP unless you want some documented magic functionality.
https://www.php.net/manual/en/language.oop5.magic.php